### PR TITLE
VG-2746: Change user-key header to appKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the `district09/gent-lez` package.
 
+## [Unreleased]
+
+### Changed
+
+- VG-2746: Change user-key header to appKey.
+
 ## [3.0.0]
 
 ### Added

--- a/examples/DetailsFromLambert72.php
+++ b/examples/DetailsFromLambert72.php
@@ -12,7 +12,7 @@ use District09\Gent\Lez\Value\Geometry\Lambert72;
 require_once __DIR__ . '/bootstrap.php';
 
 /** @var string $apiEndpoint */
-/** @var string $apiUserKey */
+/** @var string|null $apiKey */
 
 printTitle('Get the LEZ details (if any) for a given Lambert72 coordinate.');
 
@@ -31,7 +31,7 @@ if (is_null($positionX) || is_null($positionY)) {
 }
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration(endpointUri: $apiEndpoint, apiKey: $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/DetailsFromWgs84.php
+++ b/examples/DetailsFromWgs84.php
@@ -12,7 +12,7 @@ use District09\Gent\Lez\Value\Geometry\Wgs84;
 require_once __DIR__ . '/bootstrap.php';
 
 /** @var string $apiEndpoint */
-/** @var string $apiUserKey */
+/** @var string|null $apiKey */
 
 printTitle('Get the LEZ details (if any) for a given WGS84 coordinate.');
 
@@ -31,7 +31,7 @@ if (is_null($latitude) || is_null($longitude)) {
 }
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration(endpointUri: $apiEndpoint, apiKey: $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/Lambert72InLez.php
+++ b/examples/Lambert72InLez.php
@@ -12,7 +12,7 @@ use District09\Gent\Lez\Value\Geometry\Lambert72;
 require_once __DIR__ . '/bootstrap.php';
 
 /** @var string $apiEndpoint */
-/** @var string $apiUserKey */
+/** @var string $apiKey */
 
 printTitle('Check if given Lambert72 coordinate is within Gent LEZ.');
 
@@ -31,7 +31,7 @@ if (is_null($positionX) || is_null($positionY)) {
 }
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration(endpointUri: $apiEndpoint, apiKey: $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,9 +7,9 @@ and how to retrieve data from the webservice.
 
 The examples require the `config.php` file being in place and filled in.
 
-Copy the `config.example.php` file to `config.php` and fill in the
-values. Do not alter the example scripts, all variables are defined in
-the `config.php` file.
+Copy the `config.example.php` file to `config.php` and fill in the values. Do
+not alter the example scripts, all variables are defined in the `config.php`
+file.
 
 Install the libraries:
 

--- a/examples/Wgs84InLez.php
+++ b/examples/Wgs84InLez.php
@@ -12,7 +12,7 @@ use District09\Gent\Lez\Value\Geometry\Wgs84;
 require_once __DIR__ . '/bootstrap.php';
 
 /** @var string $apiEndpoint */
-/** @var string $apiUserKey */
+/** @var string $apiKey */
 
 printTitle('Check if given WGS84 coordinate is within Gent LEZ.');
 
@@ -31,7 +31,7 @@ if (is_null($latitude) || is_null($longitude)) {
 }
 
 printStep('Create the API client configuration.');
-$configuration = new Configuration($apiEndpoint, $apiUserKey);
+$configuration = new Configuration(endpointUri: $apiEndpoint, apiKey: $apiKey);
 
 printStep('Create the Guzzle client.');
 $guzzleClient = new GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);

--- a/examples/config.example.php
+++ b/examples/config.example.php
@@ -7,5 +7,5 @@
 // The service endpoint.
 $apiEndpoint = '';
 
-// Optional api endpoint user key.
-$apiUserKey = null;
+// Optional api endpoint key.
+$apiKey = null;

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -42,10 +42,10 @@ final class Client extends AbstractClient
 
         /** @var \District09\Gent\Lez\Configuration\ConfigurationInterface $configuration */
         $configuration = $this->configuration;
-        if (!empty($configuration->userKey())) {
+        if (!empty($configuration->apiKey())) {
             $request = $request->withHeader(
-                'user-key',
-                $configuration->userKey()
+                'apiKey',
+                $configuration->apiKey()
             );
         }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -12,30 +12,31 @@ use DigipolisGent\API\Client\Configuration\Configuration as BaseConfiguration;
 final class Configuration extends BaseConfiguration implements ConfigurationInterface
 {
     /**
-     * The API user key.
+     * Create configuration by its parameters.
      *
-     * @var string|null
+     * @param string $endpointUri
+     *   The base endpoint URI.
+     * @param array|null $options
+     *    The client options.
+     * @param string|null $apiKey
+     *   The API key to use (if any).
      */
-    private $userKey;
-
-    /**
-     * @inheritDoc
-     */
-    public function __construct(string $endpointUri, ?string $userKey, array $options = [])
-    {
-        if (\substr($endpointUri, -1) !== '/') {
+    public function __construct(
+        string $endpointUri,
+        ?array $options = [],
+        private ?string $apiKey = null,
+    ) {
+        if (!str_ends_with($endpointUri, '/')) {
             $endpointUri .= '/';
         }
-        parent::__construct($endpointUri, $options);
-
-        $this->userKey = $userKey;
+        parent::__construct($endpointUri, $options ?? []);
     }
 
     /**
      * @inheritDoc
      */
-    public function userKey(): ?string
+    public function apiKey(): ?string
     {
-        return $this->userKey;
+        return $this->apiKey;
     }
 }

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -16,5 +16,5 @@ interface ConfigurationInterface extends BaseConfigurationInterface
      *
      * @return string|null
      */
-    public function userKey(): ?string;
+    public function apiKey(): ?string;
 }

--- a/src/Request/LezRequest.php
+++ b/src/Request/LezRequest.php
@@ -23,7 +23,7 @@ final class LezRequest extends AbstractJsonRequest
         $lambert72 = $this->convertToLambert72($coordinates);
 
         $uri = sprintf(
-            'pointbuffer?wkid=31370&pointx=%s&pointy=%s&bufferdistance=1',
+            'spatial/Gent.LEZ/pointbuffer?wkid=31370&pointx=%s&pointy=%s&bufferdistance=1',
             $lambert72->xPosition(),
             $lambert72->yPosition()
         );

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -32,11 +32,11 @@ final class ClientTest extends TestCase
     public function noApiUserKeyAddedIfNoValueInConfiguration(): void
     {
         $configuration = $this->prophesize(ConfigurationInterface::class);
-        $configuration->userKey()->willReturn('');
+        $configuration->apiKey()->willReturn('');
 
         $finalRequestMock = $this->prophesize(RequestInterface::class);
         $finalRequestMock
-            ->withHeader('user-key', Argument::any())
+            ->withHeader('apiKey', Argument::any())
             ->shouldNotBeCalled();
         $finalRequest = $finalRequestMock->reveal();
 
@@ -71,16 +71,16 @@ final class ClientTest extends TestCase
      * API Key is send as header.
      */
     #[Test]
-    public function apiUserKeyIsSendAsHeader()
+    public function apiUserKeyIsSendAsHeader(): void
     {
         $configuration = $this->prophesize(ConfigurationInterface::class);
-        $configuration->userKey()->willReturn('fiz-baz-key');
+        $configuration->apiKey()->willReturn('fiz-baz-key');
 
         $finalRequest = $this->prophesize(RequestInterface::class)->reveal();
 
         $requestWithUserKey = $this->prophesize(RequestInterface::class);
         $requestWithUserKey
-            ->withHeader('user-key', 'fiz-baz-key')
+            ->withHeader('apiKey', 'fiz-baz-key')
             ->willReturn($finalRequest)
             ->shouldBeCalled();
 

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -21,10 +21,13 @@ final class ConfigurationTest extends TestCase
     #[Test]
     public function itCanBeCreatedFromDetails(): void
     {
-        $configuration = new Configuration('https://endpoint/', 'api-user-key');
+        $configuration = new Configuration(
+            endpointUri: 'https://endpoint/',
+            apiKey: 'api-key',
+        );
 
         self::assertEquals('https://endpoint/', $configuration->getUri());
-        self::assertEquals('api-user-key', $configuration->userKey());
+        self::assertEquals('api-key', $configuration->apiKey());
     }
 
     /**
@@ -33,10 +36,13 @@ final class ConfigurationTest extends TestCase
     #[Test]
     public function itAddsSlashToEndpointUri(): void
     {
-        $configuration = new Configuration('https://endpoint', 'api-user-key');
+        $configuration = new Configuration(
+            endpointUri: 'https://endpoint',
+            apiKey: 'api-key',
+        );
 
         self::assertEquals('https://endpoint/', $configuration->getUri());
-        self::assertEquals('api-user-key', $configuration->userKey());
+        self::assertEquals('api-key', $configuration->apiKey());
     }
 
     /**
@@ -45,9 +51,11 @@ final class ConfigurationTest extends TestCase
     #[Test]
     public function itCanBeCreatedWithoutApiUserKey(): void
     {
-        $configuration = new Configuration('https://endpoint/', null);
+        $configuration = new Configuration(
+            endpointUri: 'https://endpoint/',
+        );
 
         self::assertEquals('https://endpoint/', $configuration->getUri());
-        self::assertNull($configuration->userKey());
+        self::assertNull($configuration->apiKey());
     }
 }

--- a/tests/Request/LezRequestTest.php
+++ b/tests/Request/LezRequestTest.php
@@ -27,7 +27,7 @@ final class LezRequestTest extends TestCase
         $request = new LezRequest($coordinates);
 
         self::assertEquals(
-            'pointbuffer?wkid=31370&pointx=100&pointy=1000&bufferdistance=1',
+            'spatial/Gent.LEZ/pointbuffer?wkid=31370&pointx=100&pointy=1000&bufferdistance=1',
             $request->getRequestTarget()
         );
     }


### PR DESCRIPTION
The authentication key header name has changed in the API gatweay. This update fixes this.

## Description

The API gateway uses now another header name to identify the provided API key. This update fixes this.

## Motivation and Context

This package allows connecting direct to the NucleusSpatial API or through the API gateway. The API Gateway requires an API key. The name of the header parameter has changed from `user-key` to `apiKey`.

## How Has This Been Tested?

- Unit tests.
- Actual tests using the examples.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Documentation update.
- [x] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
